### PR TITLE
ci: Automate deployment with Terraform apply job

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,32 +1,26 @@
-# .github/workflows/build-and-push.yml (CD機能追加版)
-
 name: Build, Push, and Deploy to Cloud Run
 
 on:
   push:
-    # mainブランチにプッシュ（マージ）されたら、このワークフローを実行する
     branches:
       - main
 
 env:
-  GCP_PROJECT_ID: adept-bridge-457703-u9 # あなたのGCPプロジェクトID
-  GAR_LOCATION: asia-northeast1 # Artifact Registryのリージョン
-  SERVICE_NAME: anki-ai # イメージ名
-  REPOSITORY_NAME: anki-ai-repo # Artifact Registryのリポジトリ名
-  IMAGE_VERSION: v1.0.0 # アプリケーションのバージョン番号
+  GCP_PROJECT_ID: adept-bridge-457703-u9
+  GAR_LOCATION: asia-northeast1
+  SERVICE_NAME: anki-ai
+  REPOSITORY_NAME: anki-ai-repo
 
 jobs:
-  # --- ジョブ1: Dockerイメージのビルドとプッシュ ---
   build-and-push-image:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
-
     permissions:
       contents: "read"
       id-token: "write"
 
     outputs:
-      image_tag: ${{ steps.push-to-gar.outputs.image_tag }} # このジョブの出力としてイメージタグを定義
+      image_tag: ${{ steps.build-and-push.outputs.tag }}
 
     steps:
       - name: Checkout repository
@@ -41,31 +35,24 @@ jobs:
       - name: Configure Docker
         run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev
 
-      - name: Build and Push Docker Image with Multiple Tags
-        id: build-and-push # このステップにIDを付与
-        run: |
-          SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-8)
-          IMAGE_BASE_NAME="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.REPOSITORY_NAME }}/${{ env.SERVICE_NAME }}"
+      - name: Build and Push Docker Image
+        id: build-and-push
+        run: SHORT_SHA="sha-$(echo $GITHUB_SHA | cut -c1-8)"
+          IMAGE_URL="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.REPOSITORY_NAME }}/${{ env.SERVICE_NAME }}"
 
-          # 複数のタグを付けてビルド
           docker build --platform linux/amd64 \
-            --build-arg NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }} \
-            --build-arg NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }} \
-            -t "${IMAGE_BASE_NAME}:latest" \
-            -t "${IMAGE_BASE_NAME}:${{ env.IMAGE_VERSION }}" \
-            -t "${IMAGE_BASE_NAME}:sha-${SHORT_SHA}" \
-            .
+          --build-arg NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }} \
+          --build-arg NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }} \
+          -t "${IMAGE_URL}:${SHORT_SHA}" \
+          -t "${IMAGE_URL}:latest" \
+          .
 
-          # 全てのタグをプッシュ
-          docker push --all-tags "${IMAGE_BASE_NAME}"
+          docker push --all-tags "${IMAGE_URL}"
 
-          # このジョブの出力として、特定のタグ（例：コミットハッシュ）を次のジョブに渡す
-          echo "image_tag=sha-${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "tag=${SHORT_SHA}" >> $GITHUB_OUTPUT
 
-  # --- ★★★ ジョブ2: Terraformによるデプロイ（ここからが新しい部分） ★★★ ---
   deploy-to-cloud-run:
     name: Deploy to Cloud Run
-    # build-and-push-image ジョブが成功した後にのみ実行する
     needs: build-and-push-image
     runs-on: ubuntu-latest
 
@@ -85,13 +72,10 @@ jobs:
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: "1.5.0" # 使用するバージョンを指定
 
       - name: Terraform Init
         run: terraform init
 
       - name: Terraform Apply
-        # -auto-approve オプションで、対話なし（yesの入力なし）で自動的に適用する
-        # -var オプションで、前のジョブでビルドしたイメージタグを渡すことも可能（今回はlatestを使うので省略）
-        run: terraform apply -auto-approve
+        run: |
+          terraform apply -auto-approve -var="image_tag=${{ needs.build-and-push-image.outputs.image_tag }}"

--- a/main.tf
+++ b/main.tf
@@ -24,26 +24,22 @@ resource "google_cloud_run_v2_service" "anki_ai" {
   location = var.region
   project  = var.project_id
 
-  # 誰でもアクセスできるようにする設定
   ingress = "INGRESS_TRAFFIC_ALL"
 
   template {
-    # オートスケーリング設定
     scaling {
-      min_instance_count = 0 # 普段は0でコスト節約
+      min_instance_count = 0 
       max_instance_count = 10
     }
-    
-    # Workload Identity のためのサービスアカウントを指定
+  
     service_account = "anki-ai-runtime-sa@${var.project_id}.iam.gserviceaccount.com"
 
     containers {
-      image = "asia-northeast1-docker.pkg.dev/${var.project_id}/anki-ai-repo/anki-ai:latest"
+      image = "asia-northeast1-docker.pkg.dev/${var.project_id}/anki-ai-repo/anki-ai:${var.image_tag}"
       ports {
         container_port = 8080
       }
-
-      # 環境変数をSecret Managerから自動で設定
+      
       dynamic "env" {
         for_each = toset(local.secrets)
 

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,3 +9,9 @@ variable "region" {
   description = "The GCP region to deploy resources."
   default     = "asia-northeast1"
 }
+
+variable "image_tag" {
+  type        = string
+  description = "The Docker image tag to deploy."
+  default     = "latest"
+}


### PR DESCRIPTION
This pull request updates the CI/CD pipeline and Terraform configuration for deploying a Docker-based application to Google Cloud Run. Key changes include streamlining Docker image tagging and pushing, integrating Terraform with dynamic image tags, and adding provider configurations.

### CI/CD Pipeline Changes:
* [`.github/workflows/build-and-push.yml`](diffhunk://#diff-ff6530072f2ee96cab1b3a1bd86c4db4afa00ae564f6484789969129711495aeL1-R23): Refactored Docker image build and push steps to use a single tag (`SHORT_SHA`) and updated output handling for image tags. Removed redundant comments and simplified workflow structure. [[1]](diffhunk://#diff-ff6530072f2ee96cab1b3a1bd86c4db4afa00ae564f6484789969129711495aeL1-R23) [[2]](diffhunk://#diff-ff6530072f2ee96cab1b3a1bd86c4db4afa00ae564f6484789969129711495aeL44-L68)
* [`.github/workflows/build-and-push.yml`](diffhunk://#diff-ff6530072f2ee96cab1b3a1bd86c4db4afa00ae564f6484789969129711495aeL88-R81): Enhanced Terraform deployment step to dynamically pass the Docker image tag from the previous job using the `image_tag` output.

### Terraform Configuration Updates:
* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL27-L46): Updated the `google_cloud_run_v2_service` resource to use a dynamic image tag (`var.image_tag`) for deployment instead of hardcoding `latest`.
* [`provider.tf`](diffhunk://#diff-b1ce465309ea8053579092908d4a1eda1a02f48a6287db574dd2a2104935dd2fR1-R13): Added explicit provider configuration for Google Cloud, specifying the required version and project/region variables.
* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR12-R17): Introduced a new variable `image_tag` to allow dynamic specification of the Docker image tag.