### PR TITLE
feat: Create landing page with auth redirect

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,7 +1,12 @@
 {
-  "HomePage": {
-    "title": "Hello world!",
-    "about": "Go to the about page"
+  "LandingPage": {
+    "welcome": "Welcome to anki-ai",
+    "subtitle": "Your intelligent partner for language acquisition.\nCapture phrases frictionlessly, learn with realistic AI voices.",
+    "login": "Log In",
+    "signup": "Sign Up",
+    "signupNow": "Sign up for free",
+    "alreadyHaveAccount": "Already have an account?",
+    "loginHere": "Log in here"
   },
   "cardCreateForm": {
     "frontLabel": "Front",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1,7 +1,9 @@
 {
-  "HomePage": {
-    "title": "こんにちは!",
-    "about": "ページはここ"
+  "LandingPage": {
+    "welcome": "anki-ai へようこそ",
+    "subtitle": "あなたの言語習得を加速する、インテリジェントなパートナー。\n現実のようなAI音声で、出会ったフレーズを瞬時に学習。",
+    "login": "ログイン",
+    "signup": "サインアップ"
   },
   "cardCreateForm": {
     "frontLabel": "表面",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,12 +1,69 @@
-import { useTranslations } from 'next-intl';
-import { Link } from '@/i18n/navigation';
+// src/app/[locale]/page.tsx (ボタン/リンク分離版)
+"use client";
+
+import { useEffect } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { Link, useRouter } from "@/i18n/navigation";
+import { useParams } from "next/navigation";
+import { useTranslations } from "next-intl";
 
 export default function HomePage() {
-  const t = useTranslations('HomePage');
+  const t = useTranslations("LandingPage");
+  const { user, isLoading } = useAuth();
+  const router = useRouter();
+  const params = useParams();
+
+  const locale = Array.isArray(params?.locale)
+    ? params.locale[0]
+    : params?.locale || "en";
+
+  useEffect(() => {
+    if (!isLoading && user) {
+      console.log("User is already logged in, redirecting to /decks...");
+      router.push(`/${locale}/decks`);
+    }
+  }, [user, isLoading, router, locale]);
+
+  if (isLoading || (!isLoading && user)) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center bg-white dark:bg-gray-900">
+        <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-gray-900 dark:border-gray-100"></div>
+      </div>
+    );
+  }
+
   return (
-    <div>
-      <h1>{t('title')}</h1>
-      <Link href="/about">{t('about')}</Link>
-    </div>
+    <main className="flex min-h-screen flex-col items-center justify-center p-8 text-center bg-white dark:bg-gray-900">
+      <div className="z-10 w-full max-w-2xl">
+        <h1 className="text-4xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-6xl">
+          {t("welcome")}
+        </h1>
+        <p className="mt-6 text-lg leading-8 text-gray-600 dark:text-gray-300 whitespace-pre-line">
+          {t("subtitle")}
+        </p>
+
+        {/* ★★★ このdivブロックを修正 ★★★ */}
+        <div className="mt-10 flex flex-col items-center justify-center gap-y-4">
+          {/* プライマリーボタン (サインアップ) */}
+          <Link
+            href="/signup"
+            className="w-full max-w-xs rounded-md bg-indigo-600 px-4 py-3 text-base font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+          >
+            {t("signupNow")}
+          </Link>
+          {/* セカンダリーリンク (ログイン) */}
+          <p className="mt-6 text-sm text-gray-500 dark:text-gray-400">
+            {t("alreadyHaveAccount")}{" "}
+            <Link
+              href="/login"
+              className="font-semibold leading-6 text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+            >
+              {t("loginHere")}
+            </Link>
+          </p>
+        </div>
+        {/* ★★★ 修正ここまで ★★★ */}
+      </div>
+    </main>
   );
 }


### PR DESCRIPTION
This pull request introduces a redesign of the homepage, now referred to as the "Landing Page," with updated translations, a new layout, and improved user experience for authentication. The most important changes include replacing the "HomePage" with "LandingPage" in translations, implementing a new `LandingPage` component with dynamic routing and loading states, and adding authentication-aware redirection.

### Updates to translations:

* Replaced the "HomePage" key with "LandingPage" in `messages/en.json` and `messages/ja.json`, adding new keys for the welcome message, subtitle, login, and signup text. (`[[1]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeL2-R9)`, `[[2]](diffhunk://#diff-a6f72388b6cce7f1c3524dcc22cac5352a0f40d8aac66e47a9b0ada3c4c9f291L2-R6)`)

### Redesign of the landing page:

* Updated `src/app/[locale]/page.tsx` to implement the new `LandingPage` component, featuring:
  - A responsive layout with a welcome message, subtitle, and call-to-action buttons for signup and login.
  - Dynamic routing based on user authentication status, redirecting logged-in users to the `/decks` page.
  - A loading spinner displayed while checking authentication status. (`[src/app/[locale]/page.tsxL1-R67](diffhunk://#diff-60f04e167ad0f41b936cc3ffdf6ebaf028f2779240625a2e5f50a1b754bb0fa7L1-R67)`)